### PR TITLE
Use placeholder link in breadcrumb. Closes #5

### DIFF
--- a/index.md
+++ b/index.md
@@ -283,7 +283,7 @@ Use the custom `<breadcrumb>` element to show the current path to a particular p
   <a href="#">Home</a>
   <a href="#">Subfolder</a>
   <a href="#">Subfolder</a>
-  <a href="#">Page</a>
+  <a>Page</a>
 </breadcrumb>
 
 {% highlight html %}
@@ -291,7 +291,7 @@ Use the custom `<breadcrumb>` element to show the current path to a particular p
   <a href="#">Home</a>
   <a href="#">Subfolder</a>
   <a href="#">Subfolder</a>
-  <a href="#">Page</a>
+  <a>Page</a>
 </breadcrumb>
 {% endhighlight %}
 


### PR DESCRIPTION
Minor change. As proposed it uses HTML5 placeholder link for current page in breadcrumb component. 
